### PR TITLE
fix: manual configuration of publicPath in Webpack to resolve routing issue

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<link rel="icon" type="image/svg+xml" href="./assets/icon.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Podcasts</title>
 	</head>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+// const { BaseHrefWebpackPlugin } = require('base-href-webpack-plugin');
 
 module.exports = {
 	entry: path.resolve(__dirname, './src/index.tsx'),
@@ -70,19 +71,23 @@ module.exports = {
 	output: {
 		path: path.resolve(__dirname, './dist'),
 		filename: 'bundle.js',
+		publicPath: "/"
 	},
 	plugins: [
 		new HtmlWebpackPlugin({
-			template: './src/index.html',
+			template: './public/index.html',
 			filename: './index.html',
-			chunks: ['main'],
-			hash: true,
+			favicon: './src/assets/icon.svg',
 		}),
 		new MiniCssExtractPlugin(),
 	],
 	devServer: {
+		client: {
+			progress: true,
+		},
 		static: path.resolve(__dirname, './dist'),
 		historyApiFallback: true,
 		open: true,
+		watchFiles: ['src/**/*.tsx', 'src/**/*.ts', 'public/**/*'],
 	},
 };


### PR DESCRIPTION
Manually set the publicPath in the Webpack configuration to fix the issue where automatic publicPath determination was failing in the browser. This ensures proper routing and asset loading in the application.